### PR TITLE
Updated based on openssl 1.1.0 gem to fix "wrong argument type OpenSS…

### DIFF
--- a/ext/openssl_pkcs8/openssl_pkcs8.c
+++ b/ext/openssl_pkcs8/openssl_pkcs8.c
@@ -22,32 +22,86 @@ VALUE ePKeyError;
 VALUE eOSSLError;
 VALUE cCipher;
 
-#define GetPKey(obj, pkey) do {\
-    Data_Get_Struct(obj, EVP_PKEY, pkey);\
-    if (!pkey) { \
-    	rb_raise(rb_eRuntimeError, "PKEY wasn't initialized!");\
-    } \
-} while (0)
-#define GetPKeyRSA(obj, pkey) do { \
-    GetPKey(obj, pkey); \
-    if (EVP_PKEY_type(pkey->type) != EVP_PKEY_RSA) { /* PARANOIA? */ \
-    	ossl_raise(rb_eRuntimeError, "THIS IS NOT A RSA!") ; \
-    } \
-} while (0)
+/* from ossl.h */
+NORETURN(void ossl_raise(VALUE, const char *, ...));
+#define OSSL_MIN_PWD_LEN 4
+
+/* from ossl_pkey.h */
 #define OSSL_PKEY_SET_PRIVATE(obj) rb_iv_set((obj), "private", Qtrue)
 #define OSSL_PKEY_SET_PUBLIC(obj)  rb_iv_set((obj), "private", Qfalse)
 #define OSSL_PKEY_IS_PRIVATE(obj)  (rb_iv_get((obj), "private") == Qtrue)
+#define GetPKey(obj, pkey) do {\
+    TypedData_Get_Struct((obj), EVP_PKEY, &ossl_evp_pkey_type, (pkey)); \
+    if (!(pkey)) { \
+    rb_raise(rb_eRuntimeError, "PKEY wasn't initialized!");\
+    } \
+} while (0)
+
+/* from ossl_pkey.c */
+static void
+ossl_evp_pkey_free(void *ptr)
+{
+    EVP_PKEY_free(ptr);
+}
+
+/* from ossl_pkey.c */
+const rb_data_type_t ossl_evp_pkey_type = {
+    "OpenSSL/EVP_PKEY",
+    {
+    0, ossl_evp_pkey_free,
+    },
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY,
+};
+
+/* from ossl_pkey_rsa.c */
+#define GetPKeyRSA(obj, pkey) do { \
+    GetPKey((obj), (pkey)); \
+    if (EVP_PKEY_type((pkey)->type) != EVP_PKEY_RSA) { /* PARANOIA? */ \
+    ossl_raise(rb_eRuntimeError, "THIS IS NOT A RSA!") ; \
+    } \
+} while (0)
 #define RSA_HAS_PRIVATE(rsa) ((rsa)->p && (rsa)->q)
+
+/* from ossl_cipher.c */
+#define GetCipherInit(obj, ctx) do { \
+    TypedData_Get_Struct((obj), EVP_CIPHER_CTX, &ossl_cipher_type, (ctx)); \
+} while (0)
 #define GetCipher(obj, ctx) do { \
-    Data_Get_Struct(obj, EVP_CIPHER_CTX, ctx); \
-    if (!ctx) { \
-    	ossl_raise(rb_eRuntimeError, "Cipher not inititalized!"); \
+    GetCipherInit((obj), (ctx)); \
+    if (!(ctx)) { \
+    ossl_raise(rb_eRuntimeError, "Cipher not inititalized!"); \
     } \
 } while (0)
 #define SafeGetCipher(obj, ctx) do { \
-    OSSL_Check_Kind(obj, cCipher); \
-    GetCipher(obj, ctx); \
+    GetCipher((obj), (ctx)); \
 } while (0)
+
+/* from ossl_cipher.c */
+static void
+ossl_cipher_free(void *ptr)
+{
+    EVP_CIPHER_CTX *ctx = ptr;
+    if (ctx) {
+    EVP_CIPHER_CTX_cleanup(ctx);
+    ruby_xfree(ctx);
+    }
+}
+
+/* from ossl_cipher.c */
+static size_t
+ossl_cipher_memsize(const void *ptr)
+{
+    const EVP_CIPHER_CTX *ctx = ptr;
+    return ctx ? sizeof(*ctx) : 0;
+}
+
+/* from ossl_cipher.c */
+static const rb_data_type_t ossl_cipher_type = {
+    "OpenSSL/Cipher",
+    {0, ossl_cipher_free, ossl_cipher_memsize,},
+    0, 0,
+    RUBY_TYPED_FREE_IMMEDIATELY,
+};
 
 VALUE ossl_membio2str0(BIO *bio)
 {
@@ -112,8 +166,12 @@ int openssl_pkcs8_pem_passwd_cb(char *buf, int max_len, int flag, void *pwd)
     */
     rflag = flag ? Qtrue : Qfalse;
     pass  = rb_protect(openssl_pkcs8_pem_passwd_cb0, rflag, &status);
-    if (status) return -1; /* exception was raised. */
-    len = (int) RSTRING_LEN(pass);
+    if (status) {
+      /* ignore an exception raised. */
+      rb_set_errinfo(Qnil);
+      return -1;
+    }
+    len = RSTRING_LENINT(pass);
     if (len < 4) { /* 4 is OpenSSL hardcoded limit */
       rb_warning("password must be longer than 4 bytes");
       continue;
@@ -145,7 +203,10 @@ static VALUE openssl_rsa_to_pem_pkcs8(int argc, VALUE *argv, VALUE self)
     ciph = GetCipherPtr(cipher);
     if (!NIL_P(pass))
     {
-      passwd = StringValuePtr(pass);
+      StringValue(pass);
+      if (RSTRING_LENINT(pass) < OSSL_MIN_PWD_LEN)
+      ossl_raise(eOSSLError, "OpenSSL requires passwords to be at least four characters long");
+      passwd = RSTRING_PTR(pass);
     }
   }
 
@@ -166,7 +227,7 @@ static VALUE openssl_rsa_to_pem_pkcs8(int argc, VALUE *argv, VALUE self)
   }
   else
   {
-    if (!PEM_write_bio_PUBKEY(out, pkey))
+    if (!PEM_write_bio_RSA_PUBKEY(out, pkey->pkey.rsa))
     {
       BIO_free(out);
       ossl_raise(eRSAError, NULL);


### PR DESCRIPTION
…L::PKey::RSA (expected Data)"

On ruby 2.2.1p85, to_pem_pkcs8 hits this problem:
     TypeError:
       wrong argument type OpenSSL::PKey::RSA (expected Data)

I fixed the problem, which was with Data_Get_Struct, by updating the source based on the current openssl gem version 1.1.0.